### PR TITLE
Add support for `#[cfg]` mappings and more patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,17 @@ dependencies = [
 name = "derive-finite-automaton-derive"
 version = "0.1.0"
 dependencies = [
+ "either_n",
+ "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either_n"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c91ae510829160d5cfb19eb4ae7b6e01d44b767ca8f727c6cee936e53cc9ae5"
 
 [[package]]
 name = "proc-macro2"

--- a/derive-finite-automaton-derive/Cargo.toml
+++ b/derive-finite-automaton-derive/Cargo.toml
@@ -16,6 +16,8 @@ name = "derive_finite_automaton_derive"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["printing", "full", "parsing"] }
+proc-macro2 = "1.0"
+either_n = "0.2"
 quote = "1.0"
+syn = { version = "1.0", features = ["printing", "full", "parsing", "extra-traits"] }
 

--- a/derive-finite-automaton-derive/src/lib.rs
+++ b/derive-finite-automaton-derive/src/lib.rs
@@ -1,129 +1,12 @@
-use proc_macro::{Span, TokenStream};
-use quote::quote;
-use std::collections::HashMap;
-use syn::{
-    parse::Parse, parse_macro_input, parse_quote, Arm, DeriveInput, Expr, Ident, LitChar, LitStr,
-    Token,
-};
+mod trie;
 
-/// A trie based data structure
-#[derive(Clone)]
-struct Trie<K, V>(HashMap<K, Trie<K, V>>, Option<V>);
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Arm, DeriveInput, Expr, Ident};
+use trie::{CFGAttributes, Trie};
 
-impl<K, V> Trie<K, V> {
-    fn is_leaf(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-const NO_STATE_NAME: &str = "None";
-
-fn expand_trie(
-    trie: &Trie<char, Expr>,
-    arms: &mut Vec<Arm>,
-    states: &mut Vec<Ident>,
-    prev_state: &Ident,
-) {
-    let mut count: u8 = 0;
-    for (key, sub_trie) in trie.0.iter() {
-        let chr = LitChar::new(*key, Span::call_site().into());
-        if sub_trie.is_leaf() {
-            if let Some(value) = &sub_trie.1 {
-                let arm: Arm = parse_quote! {
-                    (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::Result {
-                        result: #value,
-                        ate_character: true
-                    },
-                };
-                arms.push(arm);
-            } else {
-                unreachable!()
-            }
-        } else {
-            let new_state = {
-                let as_string = prev_state.to_string();
-                count += 1;
-                // Creating state names:
-                if as_string.is_empty() || as_string == NO_STATE_NAME {
-                    let mut string = String::new();
-                    string.push((count + 96) as char);
-                    Ident::new(&string, Span::call_site().into())
-                } else {
-                    let mut string = as_string.clone();
-                    string.push((count + 96) as char);
-                    Ident::new(&string, Span::call_site().into())
-                }
-            };
-            states.push(new_state.clone());
-            let arm: Arm = parse_quote! {
-                (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::NewState(States::#new_state),
-            };
-            arms.push(arm);
-            expand_trie(sub_trie, arms, states, &new_state);
-            if let Some(value) = &sub_trie.1 {
-                let arm: Arm = parse_quote! {
-                    (States::#new_state, _) => ::derive_finite_automaton::GetNextResult::Result {
-                        result: #value,
-                        ate_character: false,
-                    },
-                };
-                arms.push(arm);
-            }
-        }
-    }
-    if trie.1.is_none() {
-        let expected = trie
-            .0
-            .keys()
-            .map(|key| LitChar::new(*key, Span::call_site().into()));
-        let arm: Arm = parse_quote! {
-            (States::#prev_state, chr) => ::derive_finite_automaton::GetNextResult::InvalidCharacter(::derive_finite_automaton::InvalidCharacter {
-                received: chr,
-                expected: &[ #(#expected),* ]
-            }),
-        };
-        arms.push(arm);
-    }
-}
-
-/// A comma separated list of `"*sequence*" => *output*`
-struct Mappings(syn::punctuated::Punctuated<(LitStr, syn::Expr), syn::token::Comma>);
-
-impl Parse for Mappings {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let content = input
-            .parse_terminated::<(LitStr, Expr), Token![,]>(|input| {
-                if input.peek(Token![#]) {
-                    let _ = syn::Attribute::parse_outer(input)?;
-                }
-                let string: LitStr = input.parse()?;
-                input.parse::<Token![=>]>()?;
-                let expr: Expr = input.parse()?;
-                Ok((string, expr))
-            })
-            .unwrap();
-        Ok(Self(content))
-    }
-}
-
-impl Into<Trie<char, Expr>> for Mappings {
-    fn into(self) -> Trie<char, Expr> {
-        let mut trie: Trie<char, Expr> = Trie(HashMap::new(), None);
-
-        for (string, value) in self.0 {
-            let mut node = &mut trie;
-            for chr in string.value().chars() {
-                if node.0.get(&chr).is_none() {
-                    node.0.insert(chr, Trie(HashMap::new(), None));
-                }
-                node = node.0.get_mut(&chr).unwrap();
-            }
-            node.1 = Some(value);
-        }
-
-        trie
-    }
-}
+pub(crate) const NO_STATE_NAME: &str = "None";
 
 #[proc_macro_derive(FiniteAutomataConstructor, attributes(automaton_mappings))]
 pub fn stateful_trie_constructor(input: TokenStream) -> TokenStream {
@@ -136,19 +19,19 @@ pub fn stateful_trie_constructor(input: TokenStream) -> TokenStream {
         .find(|attr| attr.path.is_ident("automaton_mappings"))
         .unwrap();
 
-    let trie: Trie<char, Expr> = mappings.parse_args::<Mappings>().unwrap().into();
+    let trie: Trie<char, CFGAttributes, Expr> =
+        mappings.parse_args::<trie::Mappings>().unwrap().into();
 
-    let mut states: Vec<Ident> = Vec::new();
-    let mut arms: Vec<Arm> = Vec::new();
+    let (mut states, mut arms): (Vec<Ident>, Vec<Arm>) = Default::default();
 
     let no_state_ident = Ident::new(NO_STATE_NAME, Span::call_site().into());
 
-    expand_trie(&trie, &mut arms, &mut states, &no_state_ident);
+    trie::expand_trie(&trie, &mut arms, &mut states, &no_state_ident);
 
     // Wrap in this const thingy to not pollute global namespace but stay accessible
-    let wrapper = Ident::new(
-        &format!("_DERIVE_stateful_trie_constructor_for_{}", name),
-        Span::call_site().into(),
+    let wrapper = format_ident!(
+        "_DERIVE_STATEFUL_TRIE_CONSTRUCTOR_FOR_{}",
+        name.to_string().to_uppercase()
     );
 
     let output = quote! {

--- a/derive-finite-automaton-derive/src/trie.rs
+++ b/derive-finite-automaton-derive/src/trie.rs
@@ -1,0 +1,372 @@
+use std::{collections::HashMap, iter};
+
+use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+use quote::quote;
+use syn::{
+    parse_quote, Arm, Error as SynError, Expr, ExprLit, Lit, LitChar, Pat, PatLit, PatOr, PatRange,
+    Token,
+};
+
+/// A trie based data structure
+///
+/// `K=key,C=condition,V=Value`
+#[derive(Clone, Debug)]
+pub(crate) struct Trie<K, C: Condition, V>(HashMap<K, (C, Trie<K, C, V>)>, Option<(C, V)>);
+
+impl<K, C: Condition, V> Trie<K, C, V> {
+    fn new() -> Self {
+        Self(HashMap::new(), None)
+    }
+
+    fn is_leaf(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+pub(crate) trait Condition {
+    fn empty() -> Self;
+    fn merge(self, other: Self) -> Self;
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CFGAttributes(Vec<TokenStream>);
+
+impl Condition for CFGAttributes {
+    fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    fn merge(mut self, mut other: Self) -> Self {
+        self.0.append(&mut other.0);
+        self
+    }
+}
+
+impl CFGAttributes {
+    fn into_attr(self) -> Option<TokenStream> {
+        if self.0.is_empty() {
+            None
+        } else {
+            let tokens = self.0;
+            Some(quote! { #[cfg(any(#(#tokens),*))] })
+        }
+    }
+}
+
+impl From<Option<TokenStream>> for CFGAttributes {
+    fn from(value: Option<TokenStream>) -> Self {
+        Self(value.into_iter().collect())
+    }
+}
+
+pub(super) fn expand_trie(
+    trie: &Trie<char, CFGAttributes, Expr>,
+    arms: &mut Vec<Arm>,
+    states: &mut Vec<Ident>,
+    prev_state: &Ident,
+) {
+    let mut count: u8 = 0;
+    for (key, (cfg_attrs, sub_trie)) in trie.0.iter() {
+        let chr = LitChar::new(*key, Span::call_site().into());
+        if sub_trie.is_leaf() {
+            if let Some((cfg_attrs, value)) = &sub_trie.1 {
+                let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
+                let arm: Arm = parse_quote! {
+                    #cfg_attrs_tokens
+                    (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::Result {
+                        result: #value,
+                        ate_character: true
+                    },
+                };
+                arms.push(arm);
+            } else {
+                unreachable!()
+            }
+        } else {
+            let new_state_name_ident = {
+                let as_string = prev_state.to_string();
+                count += 1;
+                let state_name = (count + 96) as char;
+                // Creating state names:
+                if as_string.is_empty() || as_string == crate::NO_STATE_NAME {
+                    Ident::new(&state_name.to_string(), Span::call_site().into())
+                } else {
+                    let mut string = as_string.clone();
+                    string.push(state_name);
+                    Ident::new(&string, Span::call_site().into())
+                }
+            };
+            states.push(new_state_name_ident.clone());
+
+            let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
+
+            let arm: Arm = parse_quote! {
+                #cfg_attrs_tokens
+                (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::NewState(States::#new_state_name_ident),
+            };
+            arms.push(arm);
+
+            expand_trie(sub_trie, arms, states, &new_state_name_ident);
+
+            if let Some((cfg_attrs, value)) = &sub_trie.1 {
+                let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
+                let result = quote! {
+                    ::derive_finite_automaton::GetNextResult::Result { result: #value, ate_character: false, }
+                };
+                let arm: Arm = parse_quote! {
+                    #cfg_attrs_tokens
+                    (States::#new_state_name_ident, _) => #result,
+                };
+                arms.push(arm);
+            }
+        }
+    }
+
+    // Add expected case
+    if trie.1.is_none() {
+        let expected = trie
+            .0
+            .keys()
+            .map(|key| LitChar::new(*key, Span::call_site().into()));
+
+        let result = quote! {
+            ::derive_finite_automaton::GetNextResult::InvalidCharacter(
+                ::derive_finite_automaton::InvalidCharacter {
+                    received: chr,
+                    expected: &[ #(#expected),* ]
+                }
+            )
+        };
+        let arm: Arm = parse_quote! {
+            (States::#prev_state, chr) => #result,
+        };
+        arms.push(arm);
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+enum Matcher {
+    Single(char),
+    Range { from: char, to: char },
+    Or(Vec<char>),
+}
+
+/// A comma separated list of `"*sequence*" => *output*`
+pub(super) struct Mappings(
+    syn::punctuated::Punctuated<(Vec<Matcher>, Expr, Option<TokenStream>), syn::token::Comma>,
+);
+
+impl syn::parse::Parse for Mappings {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        input
+            .parse_terminated::<_, Token![,]>(|input| {
+                let mut cfg_tokens = None;
+                if input.peek(Token![#]) {
+                    let attributes = syn::Attribute::parse_outer(input)?;
+                    for attribute in attributes {
+                        if attribute.path.is_ident("cfg") {
+                            if let Some(TokenTree::Group(group)) =
+                                attribute.tokens.into_iter().next()
+                            {
+                                cfg_tokens = Some(group.stream());
+                            } else {
+                                return Err(SynError::new(
+                                    Span::call_site(),
+                                    "Invalid cfg attribute",
+                                ));
+                            }
+                        }
+                        // Skips doc comments
+                        else if attribute.path.is_ident("doc") {
+                            return Err(SynError::new(Span::call_site(), "Unknown attribute"));
+                        }
+                    }
+                }
+                let pat: Pat = input.parse()?;
+                let matchers: Vec<Matcher> = if let Pat::Slice(slice) = pat {
+                    let mut matchers = Vec::new();
+                    for pat in slice.elems.iter() {
+                        let matcher = match pat {
+                            Pat::Lit(PatLit { expr, .. }) => {
+                                if let Expr::Lit(ExprLit {
+                                    lit: Lit::Char(chr),
+                                    ..
+                                }) = &**expr
+                                {
+                                    Matcher::Single(chr.value())
+                                } else {
+                                    return Err(SynError::new(
+                                        Span::call_site(),
+                                        "Expected character matcher",
+                                    ));
+                                }
+                            }
+                            Pat::Or(PatOr { cases, .. }) => {
+                                let mut char_cases = Vec::new();
+                                for case in cases {
+                                    if let Pat::Lit(PatLit { expr, .. }) = case {
+                                        if let Expr::Lit(ExprLit {
+                                            lit: Lit::Char(chr),
+                                            ..
+                                        }) = &**expr
+                                        {
+                                            char_cases.push(chr.value());
+                                        } else {
+                                            return Err(SynError::new(
+                                                Span::call_site(),
+                                                "Expected character matcher",
+                                            ));
+                                        }
+                                    } else {
+                                        return Err(SynError::new(
+                                            Span::call_site(),
+                                            "Expected character matcher",
+                                        ));
+                                    }
+                                }
+                                Matcher::Or(char_cases)
+                            }
+                            Pat::Range(PatRange { lo, hi, .. }) => {
+                                if let (
+                                    Expr::Lit(ExprLit {
+                                        lit: Lit::Char(chr_lo),
+                                        ..
+                                    }),
+                                    Expr::Lit(ExprLit {
+                                        lit: Lit::Char(chr_hi),
+                                        ..
+                                    }),
+                                ) = (&**lo, &**hi)
+                                {
+                                    Matcher::Range {
+                                        from: chr_lo.value(),
+                                        to: chr_hi.value(),
+                                    }
+                                } else {
+                                    return Err(SynError::new(
+                                        Span::call_site(),
+                                        "Expected character matcher",
+                                    ));
+                                }
+                            }
+                            _ => {
+                                return Err(SynError::new(
+                                    Span::call_site(),
+                                    "Expected character matcher",
+                                ));
+                            }
+                        };
+
+                        matchers.push(matcher);
+                    }
+                    matchers
+                } else if let Pat::Lit(PatLit { expr, .. }) = pat {
+                    if let Expr::Lit(ExprLit {
+                        lit: Lit::Str(string),
+                        ..
+                    }) = &*expr
+                    {
+                        string.value().chars().map(Matcher::Single).collect()
+                    } else {
+                        return Err(SynError::new(
+                            Span::call_site(),
+                            "Expected character matcher",
+                        ));
+                    }
+                } else {
+                    return Err(SynError::new(
+                        Span::call_site(),
+                        "Expected slice pattern or string literal",
+                    ));
+                };
+                input.parse::<Token![=>]>()?;
+                let expr: Expr = input.parse()?;
+                Ok((matchers, expr, cfg_tokens))
+            })
+            .map(Self)
+    }
+}
+
+impl Into<Trie<char, CFGAttributes, Expr>> for Mappings {
+    fn into(self) -> Trie<char, CFGAttributes, Expr> {
+        fn add_item<K, KC, C, V, I>(
+            node: &mut Trie<K, C, V>,
+            mut key_chain: KC,
+            condition: C,
+            value: V,
+        ) where
+            K: std::hash::Hash + PartialEq + Eq + Clone + Copy,
+            KC: Iterator<Item = I> + Clone,
+            C: Condition + Clone,
+            V: Clone,
+            I: IntoIterator<Item = K>,
+        {
+            if let Some(keys) = key_chain.next() {
+                for key in keys {
+                    if node.0.get(&key).is_none() {
+                        node.0.insert(key, (condition.clone(), Trie::new()));
+                    }
+                    add_item(
+                        &mut node.0.get_mut(&key).unwrap().1,
+                        key_chain.clone(),
+                        condition.clone(),
+                        value.clone(),
+                    )
+                }
+            } else {
+                node.1 = Some((condition, value));
+            }
+        }
+
+        let mut trie = Trie::new();
+
+        for (matches, value, cfg_attributes) in self.0 {
+            let cfg_attributes: CFGAttributes = cfg_attributes.into();
+
+            // Have to allocate the matches ahead of time because of splitting
+            let collect = matches
+                .into_iter()
+                .map(|matcher| match matcher {
+                    Matcher::Single(chr) => either_n::Either3::One(iter::once(chr)),
+                    Matcher::Range { from, to } => either_n::Either3::Two(from..to),
+                    Matcher::Or(chars) => either_n::Either3::Three(chars.into_iter()),
+                })
+                .collect::<Vec<_>>();
+            let key_chain = collect.iter().cloned();
+
+            add_item(&mut trie, key_chain, cfg_attributes, value)
+        }
+
+        trie
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::trie::Trie;
+
+    use super::Mappings;
+    use syn::{self, parse_quote};
+
+    #[test]
+    fn test_mappings() {
+        let attr: syn::Attribute = parse_quote! {
+            #[mappings(
+                "abc" => 4,
+                #[cfg(feature = "x")]
+                "abcd" => 5,
+            )]
+        };
+
+        let mappings: Mappings = attr.parse_args().unwrap();
+        let trie: Trie<_, _, _> = mappings.into();
+
+        assert!(trie.1.is_none());
+        let a = trie.0.get(&'a').unwrap();
+        let b = a.1 .0.get(&'b').unwrap();
+        let c = b.1 .0.get(&'c').unwrap();
+        assert!(c.1 .1.is_some());
+        let d = c.1 .0.get(&'d').unwrap();
+        assert!(d.1.is_leaf());
+    }
+}

--- a/derive-finite-automaton/Cargo.toml
+++ b/derive-finite-automaton/Cargo.toml
@@ -13,3 +13,7 @@ edition = "2018"
 
 [dependencies]
 derive-finite-automaton-derive = { version = "0.1.0", path = "../derive-finite-automaton-derive" }
+
+# Just for the example
+# [features]
+# special = []

--- a/derive-finite-automaton/examples/with_cfg.rs
+++ b/derive-finite-automaton/examples/with_cfg.rs
@@ -1,0 +1,27 @@
+use derive_finite_automaton::FiniteAutomataConstructor;
+
+#[derive(Debug, FiniteAutomataConstructor)]
+#[automaton_mappings(
+    "{" => Tokens::OpenBrace,
+    "}" => Tokens::CloseBrace,
+    "=>" => Tokens::ArrowFunction,
+    "==" => Tokens::Equal,
+    "===" => Tokens::StrictEqual,
+    "=" => Tokens::Assign,
+    // Some mapping
+    "." => Tokens::Dot,
+    #[cfg(feature = "special")]
+    ".?." => Tokens::Magic,
+)]
+pub enum Tokens {
+    OpenBrace,
+    CloseBrace,
+    ArrowFunction,
+    Equal,
+    StrictEqual,
+    Assign,
+    Dot,
+    Magic,
+}
+
+fn main() {}


### PR DESCRIPTION
This should allow for `#[cfg]` on mappings
```rust
#[derive(FiniteAutomataConstructor)]
#[automaton_mappings(
    "." => Tokens::Dot,
    #[cfg(feature = "special")]
    ".?." => Tokens::Magic,
)]
```
*(This requires conditionally generating intermediate stages, so implementation isn't exactly trivial)*

Also allows for slice, union and range patterns:
```rust
#[derive(Debug, FiniteAutomataConstructor)]
#[automaton_mappings(
    ['=' | '-', '>'] => Tokens::Arrow
)]
```
*(Implementation is simple atm and just expands to all the cases)*