### PR TITLE
Remove conditionals in favour of `cfg_attrs`

### DIFF
--- a/derive-finite-automaton-derive/src/trie.rs
+++ b/derive-finite-automaton-derive/src/trie.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, iter};
 
-use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{
     parse_quote, Arm, Error as SynError, Expr, ExprLit, Lit, LitChar, Pat, PatLit, PatOr, PatRange,
@@ -11,9 +11,9 @@ use syn::{
 ///
 /// `K=key,C=condition,V=Value`
 #[derive(Clone, Debug)]
-pub(crate) struct Trie<K, C: Condition, V>(HashMap<K, (C, Trie<K, C, V>)>, Option<(C, V)>);
+pub(crate) struct Trie<K, V>(HashMap<K, Trie<K, V>>, Option<V>);
 
-impl<K, C: Condition, V> Trie<K, C, V> {
+impl<K, V> Trie<K, V> {
     fn new() -> Self {
         Self(HashMap::new(), None)
     }
@@ -23,56 +23,18 @@ impl<K, C: Condition, V> Trie<K, C, V> {
     }
 }
 
-pub(crate) trait Condition {
-    fn empty() -> Self;
-    fn merge(self, other: Self) -> Self;
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct CFGAttributes(Vec<TokenStream>);
-
-impl Condition for CFGAttributes {
-    fn empty() -> Self {
-        Self(Vec::new())
-    }
-
-    fn merge(mut self, mut other: Self) -> Self {
-        self.0.append(&mut other.0);
-        self
-    }
-}
-
-impl CFGAttributes {
-    fn into_attr(self) -> Option<TokenStream> {
-        if self.0.is_empty() {
-            None
-        } else {
-            let tokens = self.0;
-            Some(quote! { #[cfg(any(#(#tokens),*))] })
-        }
-    }
-}
-
-impl From<Option<TokenStream>> for CFGAttributes {
-    fn from(value: Option<TokenStream>) -> Self {
-        Self(value.into_iter().collect())
-    }
-}
-
 pub(super) fn expand_trie(
-    trie: &Trie<char, CFGAttributes, Expr>,
+    trie: &Trie<char, Expr>,
     arms: &mut Vec<Arm>,
     states: &mut Vec<Ident>,
     prev_state: &Ident,
 ) {
     let mut count: u8 = 0;
-    for (key, (cfg_attrs, sub_trie)) in trie.0.iter() {
-        let chr = LitChar::new(*key, Span::call_site().into());
+    for (key, sub_trie) in trie.0.iter() {
+        let chr = LitChar::new(*key, Span::call_site());
         if sub_trie.is_leaf() {
-            if let Some((cfg_attrs, value)) = &sub_trie.1 {
-                let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
+            if let Some(value) = &sub_trie.1 {
                 let arm: Arm = parse_quote! {
-                    #cfg_attrs_tokens
                     (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::Result {
                         result: #value,
                         ate_character: true
@@ -86,35 +48,30 @@ pub(super) fn expand_trie(
             let new_state_name_ident = {
                 let as_string = prev_state.to_string();
                 count += 1;
-                let state_name = (count + 96) as char;
+                let state_name = (count + 'A' as u8) as char;
                 // Creating state names:
                 if as_string.is_empty() || as_string == crate::NO_STATE_NAME {
-                    Ident::new(&state_name.to_string(), Span::call_site().into())
+                    Ident::new(&state_name.to_string(), Span::call_site())
                 } else {
                     let mut string = as_string.clone();
                     string.push(state_name);
-                    Ident::new(&string, Span::call_site().into())
+                    Ident::new(&string, Span::call_site())
                 }
             };
             states.push(new_state_name_ident.clone());
 
-            let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
-
             let arm: Arm = parse_quote! {
-                #cfg_attrs_tokens
                 (States::#prev_state, #chr) => ::derive_finite_automaton::GetNextResult::NewState(States::#new_state_name_ident),
             };
             arms.push(arm);
 
             expand_trie(sub_trie, arms, states, &new_state_name_ident);
 
-            if let Some((cfg_attrs, value)) = &sub_trie.1 {
-                let cfg_attrs_tokens = cfg_attrs.clone().into_attr();
+            if let Some(value) = &sub_trie.1 {
                 let result = quote! {
                     ::derive_finite_automaton::GetNextResult::Result { result: #value, ate_character: false, }
                 };
                 let arm: Arm = parse_quote! {
-                    #cfg_attrs_tokens
                     (States::#new_state_name_ident, _) => #result,
                 };
                 arms.push(arm);
@@ -127,7 +84,7 @@ pub(super) fn expand_trie(
         let expected = trie
             .0
             .keys()
-            .map(|key| LitChar::new(*key, Span::call_site().into()));
+            .map(|key| LitChar::new(*key, Span::call_site()));
 
         let result = quote! {
             ::derive_finite_automaton::GetNextResult::InvalidCharacter(
@@ -152,177 +109,155 @@ enum Matcher {
 }
 
 /// A comma separated list of `"*sequence*" => *output*`
-pub(super) struct Mappings(
-    syn::punctuated::Punctuated<(Vec<Matcher>, Expr, Option<TokenStream>), syn::token::Comma>,
-);
+pub(super) struct Mappings(syn::punctuated::Punctuated<(Vec<Matcher>, Expr), syn::token::Comma>);
 
 impl syn::parse::Parse for Mappings {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         input
-            .parse_terminated::<_, Token![,]>(|input| {
-                let mut cfg_tokens = None;
-                if input.peek(Token![#]) {
-                    let attributes = syn::Attribute::parse_outer(input)?;
-                    for attribute in attributes {
-                        if attribute.path.is_ident("cfg") {
-                            if let Some(TokenTree::Group(group)) =
-                                attribute.tokens.into_iter().next()
-                            {
-                                cfg_tokens = Some(group.stream());
-                            } else {
-                                return Err(SynError::new(
-                                    Span::call_site(),
-                                    "Invalid cfg attribute",
-                                ));
-                            }
-                        }
-                        // Skips doc comments
-                        else if attribute.path.is_ident("doc") {
-                            return Err(SynError::new(Span::call_site(), "Unknown attribute"));
-                        }
-                    }
-                }
-                let pat: Pat = input.parse()?;
-                let matchers: Vec<Matcher> = if let Pat::Slice(slice) = pat {
-                    let mut matchers = Vec::new();
-                    for pat in slice.elems.iter() {
-                        let matcher = match pat {
-                            Pat::Lit(PatLit { expr, .. }) => {
-                                if let Expr::Lit(ExprLit {
-                                    lit: Lit::Char(chr),
-                                    ..
-                                }) = &**expr
-                                {
-                                    Matcher::Single(chr.value())
-                                } else {
-                                    return Err(SynError::new(
-                                        Span::call_site(),
-                                        "Expected character matcher",
-                                    ));
-                                }
-                            }
-                            Pat::Or(PatOr { cases, .. }) => {
-                                let mut char_cases = Vec::new();
-                                for case in cases {
-                                    if let Pat::Lit(PatLit { expr, .. }) = case {
-                                        if let Expr::Lit(ExprLit {
-                                            lit: Lit::Char(chr),
-                                            ..
-                                        }) = &**expr
-                                        {
-                                            char_cases.push(chr.value());
-                                        } else {
-                                            return Err(SynError::new(
-                                                Span::call_site(),
-                                                "Expected character matcher",
-                                            ));
-                                        }
-                                    } else {
-                                        return Err(SynError::new(
-                                            Span::call_site(),
-                                            "Expected character matcher",
-                                        ));
-                                    }
-                                }
-                                Matcher::Or(char_cases)
-                            }
-                            Pat::Range(PatRange { lo, hi, .. }) => {
-                                if let (
-                                    Expr::Lit(ExprLit {
-                                        lit: Lit::Char(chr_lo),
-                                        ..
-                                    }),
-                                    Expr::Lit(ExprLit {
-                                        lit: Lit::Char(chr_hi),
-                                        ..
-                                    }),
-                                ) = (&**lo, &**hi)
-                                {
-                                    Matcher::Range {
-                                        from: chr_lo.value(),
-                                        to: chr_hi.value(),
-                                    }
-                                } else {
-                                    return Err(SynError::new(
-                                        Span::call_site(),
-                                        "Expected character matcher",
-                                    ));
-                                }
-                            }
-                            _ => {
-                                return Err(SynError::new(
-                                    Span::call_site(),
-                                    "Expected character matcher",
-                                ));
-                            }
-                        };
+            .parse_terminated::<_, Token![,]>(parse_item_to_matchers_and_expression)
+            .map(Self)
+    }
+}
 
-                        matchers.push(matcher);
-                    }
-                    matchers
-                } else if let Pat::Lit(PatLit { expr, .. }) = pat {
+impl Mappings {
+    pub(crate) fn extend(&mut self, iter: Self) {
+        self.0.extend(iter.0)
+    }
+}
+
+fn parse_item_to_matchers_and_expression(
+    input: &syn::parse::ParseBuffer<'_>,
+) -> Result<(Vec<Matcher>, Expr), SynError> {
+    let pat: Pat = input.parse()?;
+    let matchers: Vec<Matcher> = if let Pat::Slice(slice) = pat {
+        let mut matchers = Vec::new();
+        for pat in slice.elems.iter() {
+            let matcher = match pat {
+                Pat::Lit(PatLit { expr, .. }) => {
                     if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(string),
+                        lit: Lit::Char(chr),
                         ..
-                    }) = &*expr
+                    }) = &**expr
                     {
-                        string.value().chars().map(Matcher::Single).collect()
+                        Matcher::Single(chr.value())
                     } else {
                         return Err(SynError::new(
                             Span::call_site(),
                             "Expected character matcher",
                         ));
                     }
-                } else {
+                }
+                Pat::Or(PatOr { cases, .. }) => {
+                    let mut char_cases = Vec::new();
+                    for case in cases {
+                        if let Pat::Lit(PatLit { expr, .. }) = case {
+                            if let Expr::Lit(ExprLit {
+                                lit: Lit::Char(chr),
+                                ..
+                            }) = &**expr
+                            {
+                                char_cases.push(chr.value());
+                            } else {
+                                return Err(SynError::new(
+                                    Span::call_site(),
+                                    "Expected character matcher",
+                                ));
+                            }
+                        } else {
+                            return Err(SynError::new(
+                                Span::call_site(),
+                                "Expected character matcher",
+                            ));
+                        }
+                    }
+                    Matcher::Or(char_cases)
+                }
+                Pat::Range(PatRange { lo, hi, .. }) => {
+                    if let (
+                        Expr::Lit(ExprLit {
+                            lit: Lit::Char(chr_lo),
+                            ..
+                        }),
+                        Expr::Lit(ExprLit {
+                            lit: Lit::Char(chr_hi),
+                            ..
+                        }),
+                    ) = (&**lo, &**hi)
+                    {
+                        Matcher::Range {
+                            from: chr_lo.value(),
+                            to: chr_hi.value(),
+                        }
+                    } else {
+                        return Err(SynError::new(
+                            Span::call_site(),
+                            "Expected character matcher",
+                        ));
+                    }
+                }
+                _ => {
                     return Err(SynError::new(
                         Span::call_site(),
-                        "Expected slice pattern or string literal",
+                        "Expected character matcher",
                     ));
-                };
-                input.parse::<Token![=>]>()?;
-                let expr: Expr = input.parse()?;
-                Ok((matchers, expr, cfg_tokens))
-            })
-            .map(Self)
-    }
+                }
+            };
+
+            matchers.push(matcher);
+        }
+        matchers
+    } else if let Pat::Lit(PatLit { expr, .. }) = pat {
+        if let Expr::Lit(ExprLit {
+            lit: Lit::Str(string),
+            ..
+        }) = &*expr
+        {
+            string.value().chars().map(Matcher::Single).collect()
+        } else {
+            return Err(SynError::new(
+                Span::call_site(),
+                "Expected character matcher",
+            ));
+        }
+    } else {
+        return Err(SynError::new(
+            Span::call_site(),
+            "Expected slice pattern or string literal",
+        ));
+    };
+    input.parse::<Token![=>]>()?;
+    let expr: Expr = input.parse()?;
+    Ok((matchers, expr))
 }
 
-impl Into<Trie<char, CFGAttributes, Expr>> for Mappings {
-    fn into(self) -> Trie<char, CFGAttributes, Expr> {
-        fn add_item<K, KC, C, V, I>(
-            node: &mut Trie<K, C, V>,
-            mut key_chain: KC,
-            condition: C,
-            value: V,
-        ) where
+impl From<Mappings> for Trie<char, Expr> {
+    fn from(mappings: Mappings) -> Trie<char, Expr> {
+        fn add_item<K, KC, V, I>(node: &mut Trie<K, V>, mut key_chain: KC, value: V)
+        where
             K: std::hash::Hash + PartialEq + Eq + Clone + Copy,
             KC: Iterator<Item = I> + Clone,
-            C: Condition + Clone,
             V: Clone,
             I: IntoIterator<Item = K>,
         {
             if let Some(keys) = key_chain.next() {
                 for key in keys {
                     if node.0.get(&key).is_none() {
-                        node.0.insert(key, (condition.clone(), Trie::new()));
+                        node.0.insert(key, Trie::new());
                     }
                     add_item(
-                        &mut node.0.get_mut(&key).unwrap().1,
+                        node.0.get_mut(&key).unwrap(),
                         key_chain.clone(),
-                        condition.clone(),
                         value.clone(),
                     )
                 }
             } else {
-                node.1 = Some((condition, value));
+                node.1 = Some(value);
             }
         }
 
         let mut trie = Trie::new();
 
-        for (matches, value, cfg_attributes) in self.0 {
-            let cfg_attributes: CFGAttributes = cfg_attributes.into();
-
+        for (matches, value) in mappings.0 {
             // Have to allocate the matches ahead of time because of splitting
             let collect = matches
                 .into_iter()
@@ -332,9 +267,9 @@ impl Into<Trie<char, CFGAttributes, Expr>> for Mappings {
                     Matcher::Or(chars) => either_n::Either3::Three(chars.into_iter()),
                 })
                 .collect::<Vec<_>>();
-            let key_chain = collect.iter().cloned();
 
-            add_item(&mut trie, key_chain, cfg_attributes, value)
+            let key_chain = collect.iter().cloned();
+            add_item(&mut trie, key_chain, value)
         }
 
         trie
@@ -353,20 +288,19 @@ mod tests {
         let attr: syn::Attribute = parse_quote! {
             #[mappings(
                 "abc" => 4,
-                #[cfg(feature = "x")]
                 "abcd" => 5,
             )]
         };
 
         let mappings: Mappings = attr.parse_args().unwrap();
-        let trie: Trie<_, _, _> = mappings.into();
+        let trie: Trie<_, _> = mappings.into();
 
         assert!(trie.1.is_none());
         let a = trie.0.get(&'a').unwrap();
-        let b = a.1 .0.get(&'b').unwrap();
-        let c = b.1 .0.get(&'c').unwrap();
-        assert!(c.1 .1.is_some());
-        let d = c.1 .0.get(&'d').unwrap();
-        assert!(d.1.is_leaf());
+        let b = a.0.get(&'b').unwrap();
+        let c = b.0.get(&'c').unwrap();
+        assert!(c.1.is_some());
+        let d = c.0.get(&'d').unwrap();
+        assert!(d.is_leaf());
     }
 }

--- a/derive-finite-automaton/Cargo.toml
+++ b/derive-finite-automaton/Cargo.toml
@@ -15,5 +15,5 @@ edition = "2018"
 derive-finite-automaton-derive = { version = "0.1.2", path = "../derive-finite-automaton-derive" }
 
 # Just for the example
-# [features]
-# special = []
+[features]
+special = []

--- a/derive-finite-automaton/README.md
+++ b/derive-finite-automaton/README.md
@@ -1,22 +1,25 @@
-# derive-finite-automaton
+# derive finite automaton
 
-[![Crates](https://img.shields.io/crates/v/derive-finite-automaton.svg)](https://crates.io/crates/derive-finite-automaton)
+[![crates.io badge](https://img.shields.io/crates/v/derive-finite-automaton?style=flat-square)](https://crates.io/crates/derive-finite-automaton)
+[![docs.rs badge](https://img.shields.io/docsrs/derive-finite-automaton?style=flat-square)](https://docs.rs/derive-finite-automaton/latest)
 
 A procedural macro for building a finite automaton. Main use is for lexing multiple character wide tokens see [`derive-finite-automaton/examples/main.rs`](derive-finite-automaton/examples/main.rs).
 
 Run example:
-```
+
+```shell
 cd derive-finite-automaton
 cargo run --example main
 ```
 
 View example macro expansion (requires [cargo-expand](https://github.com/dtolnay/cargo-expand)):
-```
+
+```shell
 cd derive-finite-automaton
 cargo expand --example main
 ```
 
-### Example
+## Example
 
 ```rust
 use derive_finite_automaton::{FiniteAutomata, FiniteAutomataConstructor};
@@ -41,5 +44,37 @@ pub enum Tokens {
     Assign,
     Dot,
     Spread,
+}
+```
+
+You can add conditional mappings with the following
+
+```rust
+use derive_finite_automaton::FiniteAutomataConstructor;
+
+#[derive(Debug, FiniteAutomataConstructor)]
+#[automaton_mappings(
+    "{" => Tokens::OpenBrace,
+    "}" => Tokens::CloseBrace,
+    "=>" => Tokens::ArrowFunction,
+    "==" => Tokens::Equal,
+    "===" => Tokens::StrictEqual,
+    "=" => Tokens::Assign,
+    // Some mapping
+    "." => Tokens::Dot,
+)]
+#[cfg_attr(feature = "special", automaton_mappings(
+    ".?." => Tokens::Magic,
+))]
+pub enum Tokens {
+    OpenBrace,
+    CloseBrace,
+    ArrowFunction,
+    Equal,
+    StrictEqual,
+    Assign,
+    Dot,
+    #[cfg(feature = "special")]
+    Magic,
 }
 ```

--- a/derive-finite-automaton/examples/with_cfg.rs
+++ b/derive-finite-automaton/examples/with_cfg.rs
@@ -10,9 +10,10 @@ use derive_finite_automaton::FiniteAutomataConstructor;
     "=" => Tokens::Assign,
     // Some mapping
     "." => Tokens::Dot,
-    #[cfg(feature = "special")]
-    ".?." => Tokens::Magic,
 )]
+#[cfg_attr(feature = "special", automaton_mappings(
+    ".?." => Tokens::Magic,
+))]
 pub enum Tokens {
     OpenBrace,
     CloseBrace,
@@ -21,6 +22,7 @@ pub enum Tokens {
     StrictEqual,
     Assign,
     Dot,
+    #[cfg(feature = "special")]
     Magic,
 }
 


### PR DESCRIPTION
#1 added `cfg` to branches. I thought this worked but forgot to test with `--default-features` and so was actually broken (generated impossible states, which lead to non-exhaustive match compile errors).

Turns out `cfg_attrs` is resolved before the macro and so works in this case. 

This PR removes the previous implementation and accounts for the fact there might be more than one `attribute_mappings` attributes now.